### PR TITLE
Changed absolute to relative path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@ Konfetti
 ========
 Konfetti is a little screensaver which draws (semi-transparent) confetti on your desktop:
 
-![screenshot](https://github.com/nishanth1232/Konfetti/blob/master/images/screenshot.png)
+![screenshot](./images/screenshot.png)


### PR DESCRIPTION
The uploaded image wasn't accessible, because it used an absolute path to a deleted repository. Even if it wasn't deleted, it's much nicer to use a relative path to make it portable.